### PR TITLE
Bugfix: correct payload passed to send() on cache hit and miss

### DIFF
--- a/lib/xhr-proxy.js
+++ b/lib/xhr-proxy.js
@@ -148,6 +148,7 @@ function XMLHttpRequestProxy() {
   // calls the original if the response is not found in the cache, then adds the response to the cache,
   // or calls to onload() with the cached response if found
   this.send = function() {
+    var sendArguments = arguments;
     if (options.debugMethods) console.log('[Teuthis] proxy-xhr-send ' + method_ + ' ' + url_);
     if (shouldCache(method_, url_)) {
       var mangled = cachekeymangler(url_);
@@ -177,7 +178,7 @@ function XMLHttpRequestProxy() {
             }
           }
           shouldAddToCache_ = true;
-          xhr.send.apply(xhr, arguments);
+          xhr.send.apply(xhr, sendArguments);
         }
         if (options.debugCache) console.log('[Teuthis] proxy-try-cache hit ' + method_ + ' ' + mangled);
         // hit
@@ -213,10 +214,10 @@ function XMLHttpRequestProxy() {
           }
         }
         shouldAddToCache_ = true;
-        xhr.send.apply(xhr, arguments);
+        xhr.send.apply(xhr, sendArguments);
       });
     } else {
-      xhr.send.apply(xhr, arguments);
+      xhr.send.apply(xhr, sendArguments);
     }
   };
 


### PR DESCRIPTION
When passing the original request to the original XHR, XHR Proxy's onHit and onMiss handlers were corrupting the request by passing the wrong `arguments` (i.e. handler function's arguments instead of `XMLHttpRequestProxy.send()` arguments).